### PR TITLE
fix: kubecetl -> kubectl

### DIFF
--- a/playbooks/provision.yml
+++ b/playbooks/provision.yml
@@ -102,7 +102,7 @@
       with_items:
         - kubeadm
         - kubelet
-        - kubecetl
+        - kubectl
     - name: Load modules overlay and br_netfilter
       ansible.builtin.modprobe:
         name: overlay


### PR DESCRIPTION
Une petite erreur de frappe il me semble.